### PR TITLE
Feat: Adding support for git tags to plugin + writeback of git tags on final/tagged build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,106 @@
 # rpmautospec-koji
 
-This package contains the Koji builder plugin for rpmautospec.
+This package contains the Koji plugins for rpmautospec.
 
-It processes submitted spec file which use the %autorelease and/or %autochangelog before building
-the SRPM which is used to build the installable RPM package.
+It processes submitted spec files which use the `%autorelease` and/or `%autochangelog` macros before
+building the SRPM which is used to build the installable RPM package.
+
+The package provides three plugins:
+
+- `rpmautospec_builder` — a Koji **builder** plugin that preprocesses the spec file before the SRPM
+  is built.
+- `rpmautospec_tagger` — a Koji **hub** plugin that, when a final build is tagged or a draft is
+  promoted, records the release by creating a git tag on the package's source repository.
+- `rpmautospec_git_tag_task` — a Koji **builder** plugin that handles the `createGitTag` task spawned
+  by the tagger to create and push the git tag.
+
+The tagger and git-tag task are only active when git tag rules are configured (see
+[Git tag rules](#git-tag-rules) below).
 
 ## Installation
 
-The Koji plugin `rpmautospec_builder` is meant to be installed on all Koji builder nodes running the
-`buildSRPMFromSCM` task in `/usr/lib/koji-builder-plugins/`. You can either directly place the file
-there or install the `rpmautospec_koji` Python package and symlink the module from its location in
-the Python `site-packages` directory.
+### Builder plugins
 
-The plugin can be enabled by adding `rpmautospec_builder` to the `plugins` line in the
-`/etc/kojid/kojid.conf` configuration file for the Koji builders.
+The `rpmautospec_builder` (and optionally `rpmautospec_git_tag_task`) plugins are meant to be
+installed on all Koji builder nodes running the `buildSRPMFromSCM` task, in
+`/usr/lib/koji-builder-plugins/`. You can either directly place the files there or install the
+`rpmautospec_koji` Python package and symlink the modules from their location in the Python
+`site-packages` directory.
+
+Enable them by adding `rpmautospec_builder` (and `rpmautospec_git_tag_task`) to the `plugins` line
+in the `/etc/kojid/kojid.conf` configuration file for the Koji builders.
+
+If git tag rules are defined, `rpmautospec_builder` will load and use them to determine namespaces
+for rpmautospec. For builds where no rule matches (or if there are no rules), then the plugin will
+use rpmautospec's default non-git-tag behavior.
+
+### Hub plugin
+
+The `rpmautospec_tagger` plugin is meant to be installed on the Koji hub in
+`/usr/lib/koji-hub-plugins/`, the same way as the builder plugins.
+
+Enable it by adding `rpmautospec_tagger` to the `Plugins` line in the `/etc/koji-hub/hub.conf`
+configuration file for the Koji hub.
+
+Note the tagger plugin only creates git tag tasks when both of the following apply:
+
+* The build is final (non-draft), or is being promoted to final.
+* At least one configured Koji tag rule matches.
+
+This limits git tagging to builds actually on the path to release, following TagBuild or Promote
+actions; drafts and builds in non-matching tags are left untagged.
+
+## Git tag rules
+
+The builder and hub git tag plugins read git tag rules from a `[rpmautospec]` section in their
+respective configuration files:
+
+- Builder: `/etc/kojid/plugins/rpmautospec.conf`
+- Hub: `/etc/koji-hub/plugins/rpmautospec.conf`
+
+A rule maps a Koji tag name to a git tag namespace. Each rule is written on its own line as
+`<pattern> = <namespace>`, where `<pattern>` is a regular expression matched against the Koji tag
+name (using a full match) and `<namespace>` is the resulting namespace, into which
+regular-expression backreferences such as `\1` are expanded. Rules are newline-separated
+(ConfigParser multiline values) and tried in order.
+
+```ini
+[rpmautospec]
+git_tag_rules =
+    (f\d+)-updates = fedora/\1
+    eln = fedora/eln
+```
+
+Using `=` as the separator (instead of `:`) avoids conflicts with colons in non-capturing groups
+(e.g. `(?:...)`) and using newlines avoids conflicts with commas in regex quantifiers
+(e.g. `{2,3}`).
+
+The two sides use the rules for complementary purposes:
+
+- On the **hub**, the tagger matches the destination Koji tag of a completed build; a match means the
+  build is a release and a git tag is created in the resulting namespace. Patterns here are typically
+  narrow, so that only release tags trigger tagging.
+- On the **builder**, the plugin matches the build tag to determine which namespace to read existing
+  git tags from when computing the release number and changelog. Patterns here are typically broader,
+  so that all builds for a target resolve to the same namespace.
+
+If `git_tag_rules` is not set, the hub plugin creates no tags and the builder plugin falls back to
+computing the release and changelog from the commit history.
+
+## Changelog options
+
+The builder plugin also supports optional changelog configuration in the same config file:
+
+```ini
+[rpmautospec]
+git_tag_rules =
+    (f\d+)(-.*)? = fedora/\1
+changelog_mode = accumulated
+changelog_use_highest_release_tag = false
+```
+
+- `changelog_mode`: either `accumulated` (default) or `tagged-only`. In `accumulated` mode, the
+  changelog includes all commits between tags, attributed to their authors. In `tagged-only` mode,
+  only tagged commits produce changelog entries.
+- `changelog_use_highest_release_tag`: when `true`, if a commit has multiple release tags, use the
+  highest release number. Default is `false` (use the lowest/first).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rpmautospec-koji"
-version = "0.4.0"
+version = "0.5.0"
 description = "Koji plugin for rpmautospec"
 authors = ["Nils Philippsen <nils@redhat.com>"]
 license = "MIT"
@@ -24,7 +24,7 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-rpmautospec_core = "^0.1.0"
+rpmautospec_core = "^0.2.0"
 rpmautospec = { git = "https://github.com/fedora-infra/rpmautospec.git", branch = "main" }
 koji = "^1.33.0"
 ruff = "^0.1.14 || ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0"

--- a/rpmautospec_koji/rpmautospec_builder.py
+++ b/rpmautospec_koji/rpmautospec_builder.py
@@ -1,20 +1,84 @@
+import glob
 import logging
+import os
 
 from koji.plugin import callback
 
 from rpmautospec import process_distgit
-
+from rpmautospec_koji.util import match_tag_rules, parse_config
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+CONFIG_FILE = "/etc/kojid/plugins/rpmautospec.conf"
+
+
+def _get_config():
+    """Read plugin config."""
+    return parse_config(CONFIG_FILE)
+
+
+def _resolve_specfile(srcdir):
+    """Resolve the actual spec file to process within an SCM checkout dir.
+
+    PkgHistoryProcessor's directory mode assumes the checkout directory is
+    named after the package, i.e. it looks for "<dirname>/<dirname>.spec".
+    That assumption doesn't hold for SCM layouts where the checkout
+    directory name doesn't match the spec file's.
+
+    1. Look for "*.spec" directly in srcdir.
+    2. If none found, also look under "srcdir/SPECS/*.spec"
+    3. If exactly one spec file was found (in either location), use it.
+    4. If more than one was found, prefer one whose base name matches the
+       checkout directory's base name.
+    5. Otherwise (zero matches, or multiple with no matching name), fall
+       back to returning srcdir unchanged and let process_distgit's own
+       directory-mode handling raise/behave as it already does.
+
+    This is effectively Koji's SRPM-from-SCM task logic.
+
+    :param srcdir: the SCM checkout directory
+    :return: path to the resolved spec file, or srcdir unchanged
+    """
+    spec_files = glob.glob(os.path.join(srcdir, "*.spec"))
+
+    if not spec_files:
+        spec_files = glob.glob(os.path.join(srcdir, "SPECS", "*.spec"))
+
+    if len(spec_files) == 1:
+        return spec_files[0]
+    if len(spec_files) > 1:
+        dirname = os.path.basename(os.path.normpath(srcdir))
+        for candidate in (
+            os.path.join(srcdir, f"{dirname}.spec"),
+            os.path.join(srcdir, "SPECS", f"{dirname}.spec"),
+        ):
+            if candidate in spec_files:
+                return candidate
+
+    return srcdir
+
 
 @callback("postSCMCheckout")
 def process_distgit_cb(cb_type, *, srcdir, taskinfo, **kwargs):
+    # This callback should only run for SRPM builds from SCM;
+    # i.e. maven and image builds don't have spec files.
     if taskinfo["method"] != "buildSRPMFromSCM":
-        # callback should be run only in this instance
-        # i.e. maven and image builds don't have spec-files
         return
 
-    if not process_distgit(srcdir, enable_caching=False):
+    git_tag_namespace = None
+    config = _get_config()
+    if config["git_tag_rules"]:
+        build_tag = kwargs.get("build_tag", {})
+        tag_name = build_tag.get("name", "")
+        if tag_name:
+            git_tag_namespace = match_tag_rules(tag_name, config["git_tag_rules"])
+
+    if not process_distgit(
+        _resolve_specfile(srcdir),
+        enable_caching=False,
+        git_tag_namespace=git_tag_namespace,
+        changelog_mode=config["changelog_mode"],
+        changelog_use_highest_release_tag=config["changelog_use_highest_release_tag"],
+    ):
         log.info("No %autorelease/%autochangelog features used, skipping.")

--- a/rpmautospec_koji/rpmautospec_git_tag_task.py
+++ b/rpmautospec_koji/rpmautospec_git_tag_task.py
@@ -1,0 +1,51 @@
+import subprocess
+import tempfile
+
+import koji.tasks
+
+__all__ = ("CreateGitTagTask",)
+
+
+class CreateGitTagTask(koji.tasks.BaseTaskHandler):
+    """Handler for git tag creation/writeback tasks
+
+    Shallow-clones the SCM, creates a tag on the desired commit, and pushes.
+    """
+
+    Methods = ["createGitTag"]
+
+    _taskWeight = 0.2
+
+    def handler(self, scm_url, tag_name):
+        """Create and push a git tag.
+
+        :param scm_url: Koji SCM URL (e.g. "git+https://src.fedoraproject.org/rpms/pkg#hash")
+        :param tag_name: tag to create (e.g. "f44-pkg-1.0-2")
+        """
+        if "#" not in scm_url:
+            raise koji.GenericError(f"SCM URL missing commit hash: {scm_url}")
+
+        url_part, commit = scm_url.rsplit("#", 1)
+        # Strip SCM scheme prefix (e.g. "git+https://...")
+        if "+" in url_part and "://" in url_part:
+            url_part = url_part.split("+", 1)[1]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._run_git(["init", "--bare", tmpdir])
+            self._run_git(["-C", tmpdir, "remote", "add", "--", "origin", url_part])
+            self._run_git(["-C", tmpdir, "fetch", "--depth=1", "origin", "--", commit])
+            self._run_git(["-C", tmpdir, "tag", "-a", "-m", tag_name, "--", tag_name, commit])
+            self._run_git(["-C", tmpdir, "push", "origin", "--", tag_name])
+
+        self.logger.info("Created git tag %s on %s", tag_name, commit[:12])
+
+    def _run_git(self, args, timeout=60):
+        """Run a git command, raising on failure."""
+        result = subprocess.run(
+            ["git"] + args,
+            capture_output=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            raise koji.GenericError(f"git {args[0]} failed: {stderr}")

--- a/rpmautospec_koji/rpmautospec_tagger.py
+++ b/rpmautospec_koji/rpmautospec_tagger.py
@@ -1,0 +1,110 @@
+"""Hub plugin: spawn a createGitTag task when a build is tagged.
+
+When a build is tagged into a qualifying destination, this plugin queues
+a builder task to push a git tag of the form {namespace}/{name}-{version}-{release}
+to the source SCM.
+
+Configuration (/etc/koji-hub/plugins/rpmautospec.conf):
+
+    [rpmautospec]
+    # Rules: {regex}:{template} (first match wins, comma-separated)
+    # Regex capture groups (\1, \2) are expanded in the template.
+    git_tag_rules = (f\\d+)-updates:fedora/\\1, eln:fedora/eln
+    # would result in f44-updates builds going to fedora/f44
+
+Note: This requires your Koji have permission to write back to git SCMs.
+You may prefer to use a separate microservice depending on your Koji's
+and git security models.
+If you do not want this enabled, do not set git_tag_rules in Hub config.
+(builder config is fine, that only triggers tag *read* for build prep)
+"""
+
+
+import logging
+
+import koji
+from koji.plugin import callback
+from kojihub import context, make_task
+from rpmautospec_core.nvr_util import format_namespaced_nvr
+
+from rpmautospec_koji.util import match_tag_rules, parse_tag_rules
+
+log = logging.getLogger(__name__)
+
+CONFIG_FILE = "/etc/koji-hub/plugins/rpmautospec.conf"
+_config = None
+
+
+def _get_config():
+    """Read plugin config. Cached after first call."""
+    global _config
+    if _config is not None:
+        return _config
+    _config = {"git_tag_rules": parse_tag_rules(CONFIG_FILE)}
+    return _config
+
+
+def _resolve_namespace(tag_name):
+    """Match a Koji tag name against rules and return the resolved namespace, or None."""
+    config = _get_config()
+    return match_tag_rules(tag_name, config["git_tag_rules"])
+
+
+@callback("postTag")
+def create_git_tag_on_tag(cbtype, *, tag, build, **kws):
+    """Queue a createGitTag task when a final build is tagged into a qualifying target."""
+    if build.get("draft"):
+        return
+
+    _try_create_tag(tag.get("name", ""), build)
+
+
+@callback("postBuildPromote")
+def create_git_tag_on_promote(cbtype, *, build, **kws):
+    """Queue a createGitTag task when a draft build is promoted in a qualifying tag."""
+    config = _get_config()
+    if not config["git_tag_rules"]:
+        return
+
+    try:
+        build_tags = context.handlers.call("listTags", build=build.get("build_id"))
+        for bt in build_tags:
+            if _resolve_namespace(bt.get("name", "")) is not None:
+                _try_create_tag(bt["name"], build)
+                break
+    except Exception:
+        log.exception("Failed to look up tags for promoted build %s", build.get("nvr"))
+
+
+def _try_create_tag(tag_name, build):
+    """Attempt to spawn a createGitTag task for a build in the given tag."""
+    namespace = _resolve_namespace(tag_name)
+    if namespace is None:
+        return
+
+    source = build.get("source")
+    if not source or "#" not in source:
+        log.debug("Build %s has no source SCM commit, skipping git tag", build.get("nvr"))
+        return
+
+    # Strip dist suffix from release (e.g. "2.fc44" -> "2") and validate
+    release = build["release"].split(".", 1)[0]
+    if not release.isdigit():
+        log.debug("Build %s has non-numeric release %s, skipping git tag", build.get("nvr"), release)
+        return
+
+    git_tag_name = format_namespaced_nvr(
+        namespace, build["name"], build["version"], release,
+        epoch=str(build["epoch"]) if build.get("epoch") is not None else "",
+    )
+
+    try:
+        task_id = make_task(
+            "createGitTag",
+            [source, git_tag_name],
+            priority=koji.PRIO_DEFAULT + 5,
+            channel="default",
+        )
+        log.info("Spawned createGitTag task %s for %s (%s)", task_id, build["nvr"], git_tag_name)
+    except Exception:
+        log.error("Failed to spawn createGitTag task for %s", build.get("nvr"), exc_info=True)

--- a/rpmautospec_koji/util.py
+++ b/rpmautospec_koji/util.py
@@ -1,0 +1,87 @@
+"""Shared utilities for rpmautospec Koji plugins."""
+
+import logging
+import re
+
+import koji
+
+logger = logging.getLogger(__name__)
+
+
+def match_tag_rules(tag_name, rules):
+    """Match a tag name against rules and expand the namespace template.
+
+    Rules are (regex_pattern, template) tuples. The template can reference
+    capture groups from the pattern using \\1, \\2, etc.
+
+    Example:
+        rules = [("(f\\d+)-updates", "fedora/\\1")]
+        match_tag_rules("f44-updates", rules) -> "fedora/f44"
+
+    :param tag_name: the Koji tag name to match
+    :param rules: list of (pattern, template) tuples
+    :return: expanded namespace string, or None if no rule matches
+    """
+    for pattern, template in rules:
+        m = re.fullmatch(pattern, tag_name)
+        if m:
+            return m.expand(template)
+    return None
+
+
+def parse_tag_rules(config_path):
+    """Read git_tag_rules from a Koji plugin config file.
+
+    Rules are newline-separated in the config file (ConfigParser multiline),
+    with '=' separating pattern from template:
+
+        [rpmautospec]
+        git_tag_rules =
+            (f\\d+)-updates = fedora/\\1
+            (f\\d{2,3})-build = fedora/\\1
+
+    Using '=' as separator avoids conflicts with ':' in regex (e.g. (?:...))
+    and ',' in quantifiers (e.g. {2,3}).
+
+    :param config_path: path to the .conf file
+    :return: list of (pattern, template) tuples
+    """
+    cp = koji.read_config_files(config_path, raw=True)
+    rules = []
+    if not cp.has_section("rpmautospec"):
+        return rules
+    if not cp.has_option("rpmautospec", "git_tag_rules"):
+        return rules
+
+    raw = cp.get("rpmautospec", "git_tag_rules")
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if "=" not in line:
+            logger.warning(f"Skipping malformed git_tag_rules entry: {line}")
+            continue
+        pattern, template = line.split("=", 1)
+        rules.append((pattern.strip(), template.strip()))
+    return rules
+
+
+def parse_config(config_path):
+    """Read full rpmautospec plugin config.
+
+    :param config_path: path to the .conf file
+    :return: dict with git_tag_rules, changelog_mode, changelog_use_highest_release_tag
+    """
+    result = {
+        "git_tag_rules": parse_tag_rules(config_path),
+        "changelog_mode": "accumulated",
+        "changelog_use_highest_release_tag": False,
+    }
+    cp = koji.read_config_files(config_path, raw=True)
+    if cp and cp.has_section("rpmautospec"):
+        if cp.has_option("rpmautospec", "changelog_mode"):
+            result["changelog_mode"] = cp.get("rpmautospec", "changelog_mode")
+        if cp.has_option("rpmautospec", "changelog_use_highest_release_tag"):
+            val = cp.get("rpmautospec", "changelog_use_highest_release_tag")
+            result["changelog_use_highest_release_tag"] = val.lower() in ("true", "yes", "1")
+    return result

--- a/tests/fixtures/builder_full.conf
+++ b/tests/fixtures/builder_full.conf
@@ -1,0 +1,3 @@
+[rpmautospec]
+git_tag_rules =
+    (f\d+)(-.*)? = fedora/\1

--- a/tests/fixtures/builder_malformed.conf
+++ b/tests/fixtures/builder_malformed.conf
@@ -1,0 +1,4 @@
+[rpmautospec]
+git_tag_rules =
+    bad-entry
+    (f\d+)-build = fedora/\1

--- a/tests/fixtures/tagger_full.conf
+++ b/tests/fixtures/tagger_full.conf
@@ -1,0 +1,3 @@
+[rpmautospec]
+git_tag_rules =
+    (f\d+)-updates = fedora/\1

--- a/tests/fixtures/tagger_malformed.conf
+++ b/tests/fixtures/tagger_malformed.conf
@@ -1,0 +1,4 @@
+[rpmautospec]
+git_tag_rules =
+    bad-entry
+    (f\d+)-updates = fedora/\1

--- a/tests/test_rpmautospec_builder.py
+++ b/tests/test_rpmautospec_builder.py
@@ -1,18 +1,49 @@
 import logging
+import tempfile
+from pathlib import Path
 from unittest import mock
 
 import pytest
+from rpmautospec_koji import rpmautospec_builder
+from rpmautospec_koji.rpmautospec_builder import _get_config, _resolve_specfile, process_distgit_cb
 
-from rpmautospec_koji.rpmautospec_builder import process_distgit_cb
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+DEFAULT_CONFIG = {
+    "git_tag_rules": [],
+    "changelog_mode": "accumulated",
+    "changelog_use_highest_release_tag": False,
+}
 
 
-class MockConfig:
-    test_config = {
-        "pagure": {"url": "src.fedoraproject.org", "token": "aaabbbcc"},
-    }
+class TestGetConfig:
+    """Test _get_config reads real config files."""
 
-    def get(self, section, option, **kwargs):
-        return self.test_config[section][option]
+    def test_no_config_file(self, tmp_path):
+        with mock.patch.object(rpmautospec_builder, "CONFIG_FILE", str(tmp_path / "missing.conf")):
+            assert _get_config() == DEFAULT_CONFIG
+
+    def test_empty_config(self, tmp_path):
+        conf = tmp_path / "rpmautospec.conf"
+        conf.write_text("")
+        with mock.patch.object(rpmautospec_builder, "CONFIG_FILE", str(conf)):
+            assert _get_config() == DEFAULT_CONFIG
+
+    def test_with_rules(self):
+        with mock.patch.object(rpmautospec_builder, "CONFIG_FILE", str(FIXTURES_DIR / "builder_full.conf")):
+            result = _get_config()
+        assert result["git_tag_rules"] == [(r"(f\d+)(-.*)?", r"fedora/\1")]
+
+    def test_section_without_rules(self, tmp_path):
+        conf = tmp_path / "rpmautospec.conf"
+        conf.write_text("[rpmautospec]\n")
+        with mock.patch.object(rpmautospec_builder, "CONFIG_FILE", str(conf)):
+            assert _get_config() == DEFAULT_CONFIG
+
+    def test_malformed_entry_skipped(self):
+        with mock.patch.object(rpmautospec_builder, "CONFIG_FILE", str(FIXTURES_DIR / "builder_malformed.conf")):
+            result = _get_config()
+        assert result["git_tag_rules"] == [(r"(f\d+)-build", r"fedora/\1")]
 
 
 class TestBuilderPlugin:
@@ -20,14 +51,8 @@ class TestBuilderPlugin:
 
     data_build_tag = {
         "id": 11522,
-        "name": "f32-build",
+        "name": "f44-build",
         "arches": "armv7hl i686 x86_64 aarch64 ppc64le s390x",
-        "extra": {},
-        "locked": False,
-        "maven_include_all": False,
-        "maven_support": False,
-        "perm": "admin",
-        "perm_id": 1,
     }
 
     @pytest.mark.parametrize(
@@ -36,45 +61,238 @@ class TestBuilderPlugin:
             "normal",
             "other taskinfo method",
             "no features used",
+            "namespace from build tag",
+            "namespace from candidate tag",
+            "no rules configured",
+            "empty build tag",
         ),
     )
     @mock.patch("rpmautospec_koji.rpmautospec_builder.process_distgit")
-    @mock.patch("koji.read_config_files")
-    def test_process_distgit_cb(
-        self,
-        read_config_files,
-        process_distgit_fn,
-        testcase,
-        caplog,
-    ):
-        """Test the process_distgit_cb() function"""
-        read_config_files.return_value = MockConfig()
-
+    @mock.patch("rpmautospec_koji.rpmautospec_builder._get_config")
+    def test_process_distgit_cb(self, get_config_fn, process_distgit_fn, testcase, caplog):
         taskinfo_method_responsible = testcase != "other taskinfo method"
 
-        # prepare test environment
+        # Default: broad regex matches any f44-* build tag
+        rules = [(r"(f\d+)(-.*)?", r"fedora/\1")]
+
+        if testcase == "no rules configured":
+            rules = []
+        elif testcase == "namespace from candidate tag":
+            # f44-updates-candidate also resolves to fedora/f44 (broad read regex)
+            pass
+
+        get_config_fn.return_value = {
+            "git_tag_rules": rules,
+            "changelog_mode": "accumulated",
+            "changelog_use_highest_release_tag": False,
+        }
+
         specfile_dir = "some dummy path"
         args = ["postSCMCheckout"]
-        koji_session = mock.MagicMock()
         kwargs = {
             "build_tag": self.data_build_tag,
             "scratch": mock.MagicMock(),
             "srcdir": specfile_dir,
             "taskinfo": {"method": "buildSRPMFromSCM"},
-            "session": koji_session,
         }
 
-        # return value is if processing was needed
         process_distgit_fn.return_value = testcase != "no features used"
 
         if not taskinfo_method_responsible:
             kwargs["taskinfo"]["method"] = "not the method you're looking for"
+        if testcase == "namespace from candidate tag":
+            kwargs["build_tag"] = {"name": "f44-updates-candidate"}
+        if testcase == "empty build tag":
+            kwargs["build_tag"] = {"name": ""}
 
-        # test the callback
         with caplog.at_level(logging.DEBUG):
             process_distgit_cb(*args, **kwargs)
 
+        if not taskinfo_method_responsible:
+            process_distgit_fn.assert_not_called()
+        elif testcase in ("namespace from build tag", "namespace from candidate tag"):
+            process_distgit_fn.assert_called_once_with(
+                specfile_dir, enable_caching=False, git_tag_namespace="fedora/f44",
+                changelog_mode="accumulated", changelog_use_highest_release_tag=False
+            )
+        elif testcase in ("no rules configured", "empty build tag"):
+            process_distgit_fn.assert_called_once_with(
+                specfile_dir, enable_caching=False, git_tag_namespace=None,
+                changelog_mode="accumulated", changelog_use_highest_release_tag=False
+            )
+        else:
+            process_distgit_fn.assert_called_once_with(
+                specfile_dir, enable_caching=False, git_tag_namespace="fedora/f44",
+                changelog_mode="accumulated", changelog_use_highest_release_tag=False
+            )
+
         if testcase == "no features used":
             assert "skipping" in caplog.text
-        else:
+        elif taskinfo_method_responsible:
             assert not caplog.records
+
+    @mock.patch("rpmautospec_koji.rpmautospec_builder.process_distgit")
+    @mock.patch("rpmautospec_koji.rpmautospec_builder._get_config")
+    def test_resolve_mismatched_dirname_specfile(self, get_config_fn, process_distgit_fn):
+        """Checkout dirs whose name doesn't match the spec file's
+        must still resolve to the real spec file, not the directory.
+        """
+        get_config_fn.return_value = dict(DEFAULT_CONFIG)
+        process_distgit_fn.return_value = True
+
+        with tempfile.TemporaryDirectory(prefix="distro-packaging-pngcrush-") as srcdir:
+            specfile = Path(srcdir) / "pngcrush.spec"
+            specfile.write_text("Name: pngcrush\n")
+
+            process_distgit_cb(
+                "postSCMCheckout",
+                build_tag={"name": "f44-build"},
+                scratch=None,
+                srcdir=srcdir,
+                taskinfo={"method": "buildSRPMFromSCM"},
+            )
+
+            process_distgit_fn.assert_called_once_with(
+                str(specfile),
+                enable_caching=False,
+                git_tag_namespace=None,
+                changelog_mode="accumulated",
+                changelog_use_highest_release_tag=False,
+            )
+
+    @mock.patch("rpmautospec_koji.rpmautospec_builder.process_distgit")
+    @mock.patch("rpmautospec_koji.rpmautospec_builder._get_config")
+    def test_resolve_dirname_matches_specfile(self, get_config_fn, process_distgit_fn):
+        get_config_fn.return_value = dict(DEFAULT_CONFIG)
+        process_distgit_fn.return_value = True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pkgdir = Path(tmp) / "somepkg"
+            pkgdir.mkdir()
+            specfile = pkgdir / "somepkg.spec"
+            specfile.write_text("Name: somepkg\n")
+
+            process_distgit_cb(
+                "postSCMCheckout",
+                build_tag={"name": "f44-build"},
+                scratch=None,
+                srcdir=str(pkgdir),
+                taskinfo={"method": "buildSRPMFromSCM"},
+            )
+
+            process_distgit_fn.assert_called_once_with(
+                str(specfile),
+                enable_caching=False,
+                git_tag_namespace=None,
+                changelog_mode="accumulated",
+                changelog_use_highest_release_tag=False,
+            )
+
+
+class TestResolveSpecfile:
+    """Behavioral coverage for _resolve_specfile's discovery
+    This is a mirror of kojid's BuildSRPMFromSCMTask logic/testing
+    """
+
+    # --- Single spec file, flat layout ---
+
+    def test_single_specfile_mismatched_dirname_resolved(self, tmp_path):
+        specfile = tmp_path / "pngcrush.spec"
+        specfile.write_text("Name: pngcrush\n")
+
+        assert _resolve_specfile(str(tmp_path)) == str(specfile)
+
+    def test_single_specfile_matching_dirname_resolved(self, tmp_path):
+        pkgdir = tmp_path / "pkgname"
+        pkgdir.mkdir()
+        specfile = pkgdir / "pkgname.spec"
+        specfile.write_text("Name: pkgname\n")
+
+        assert _resolve_specfile(str(pkgdir)) == str(specfile)
+
+    def test_single_specfile_with_trailing_slash_in_srcdir(self, tmp_path):
+        specfile = tmp_path / "pkg.spec"
+        specfile.write_text("Name: pkg\n")
+
+        assert _resolve_specfile(str(tmp_path) + "/") == str(specfile)
+
+    # --- SPECS/ subdir layout ---
+
+    def test_single_specfile_in_specs_subdir_resolved(self, tmp_path):
+        specs_dir = tmp_path / "SPECS"
+        specs_dir.mkdir()
+        specfile = specs_dir / "pngcrush.spec"
+        specfile.write_text("Name: pngcrush\n")
+
+        assert _resolve_specfile(str(tmp_path)) == str(specfile)
+
+    def test_flat_specfile_preferred_over_specs_subdir(self, tmp_path):
+        """If a spec file exists directly in srcdir, SPECS/ is skipped"""
+        flat_spec = tmp_path / "pkg.spec"
+        flat_spec.write_text("Name: pkg\n")
+        specs_dir = tmp_path / "SPECS"
+        specs_dir.mkdir()
+        (specs_dir / "other.spec").write_text("Name: other\n")
+
+        assert _resolve_specfile(str(tmp_path)) == str(flat_spec)
+
+    def test_multiple_in_specs_subdir_with_dirname_match_resolved(self, tmp_path):
+        pkgdir = tmp_path / "mypkg"
+        specs_dir = pkgdir / "SPECS"
+        specs_dir.mkdir(parents=True)
+        matching = specs_dir / "mypkg.spec"
+        matching.write_text("Name: mypkg\n")
+        (specs_dir / "other.spec").write_text("Name: other\n")
+
+        assert _resolve_specfile(str(pkgdir)) == str(matching)
+
+    # --- Multiple spec files, flat layout ---
+
+    def test_multiple_specfiles_no_dirname_match_falls_back_to_srcdir(self, tmp_path):
+        (tmp_path / "a.spec").write_text("Name: a\n")
+        (tmp_path / "b.spec").write_text("Name: b\n")
+
+        assert _resolve_specfile(str(tmp_path)) == str(tmp_path)
+
+    def test_multiple_specfiles_with_dirname_match_resolved(self, tmp_path):
+        """When there are multiple spec files, the one matching the
+        checkout dir wins.
+        """
+        pkgdir = tmp_path / "winner"
+        pkgdir.mkdir()
+        matching = pkgdir / "winner.spec"
+        matching.write_text("Name: winner\n")
+        (pkgdir / "loser.spec").write_text("Name: loser\n")
+
+        assert _resolve_specfile(str(pkgdir)) == str(matching)
+
+    # --- Zero spec files ---
+
+    def test_empty_dir_falls_back_to_srcdir(self, tmp_path):
+        assert _resolve_specfile(str(tmp_path)) == str(tmp_path)
+
+    def test_dir_with_non_spec_files_falls_back_to_srcdir(self, tmp_path):
+        (tmp_path / "sources").write_text("stuff\n")
+        (tmp_path / "fetch").write_text("#!/bin/sh\n")
+
+        assert _resolve_specfile(str(tmp_path)) == str(tmp_path)
+
+    def test_empty_specs_subdir_falls_back_to_srcdir(self, tmp_path):
+        (tmp_path / "SPECS").mkdir()
+        assert _resolve_specfile(str(tmp_path)) == str(tmp_path)
+
+    # --- Nonexistent / inaccessible paths ---
+
+    def test_nonexistent_dir_falls_back_to_srcdir(self):
+        missing = "/no/such/directory/at/all"
+        assert _resolve_specfile(missing) == missing
+
+    def test_file_path_instead_of_dir_falls_back_to_srcdir(self, tmp_path):
+        """srcdir should be a directory. If it's a file then
+        globbing "<file>/*.spec" can't match anything so we
+        fall back rather than raising.
+        """
+        not_a_dir = tmp_path / "not_a_directory"
+        not_a_dir.write_text("just a file\n")
+
+        assert _resolve_specfile(str(not_a_dir)) == str(not_a_dir)

--- a/tests/test_rpmautospec_git_tag_task.py
+++ b/tests/test_rpmautospec_git_tag_task.py
@@ -1,0 +1,139 @@
+from unittest import mock
+
+import koji
+import pytest
+from rpmautospec_koji.rpmautospec_git_tag_task import CreateGitTagTask
+
+
+class TestCreateGitTagTask:
+
+    def _make_task(self):
+        session = mock.MagicMock()
+        options = mock.MagicMock()
+        options.workdir = "/tmp"
+        task = CreateGitTagTask(
+            id=1,
+            method="createGitTag",
+            params=[["git+https://src.example.com/rpms/pkg#abc123", "f44-pkg-1.0-2"], {}],
+            session=session,
+            options=options,
+        )
+        return task
+
+    @mock.patch("rpmautospec_koji.rpmautospec_git_tag_task.subprocess.run")
+    def test_handler_success(self, mock_run):
+        mock_run.return_value = mock.MagicMock(returncode=0)
+        task = self._make_task()
+        task.handler("git+https://src.example.com/rpms/pkg#abc123", "f44-pkg-1.0-2")
+
+        assert mock_run.call_count == 5
+        calls = mock_run.call_args_list
+        # init --bare
+        assert "init" in calls[0][0][0]
+        assert "--bare" in calls[0][0][0]
+        # remote add
+        assert "remote" in calls[1][0][0]
+        assert "https://src.example.com/rpms/pkg" in calls[1][0][0]
+        # fetch specific commit
+        assert "fetch" in calls[2][0][0]
+        assert "abc123" in calls[2][0][0]
+        # tag
+        assert "tag" in calls[3][0][0]
+        assert "f44-pkg-1.0-2" in calls[3][0][0]
+        assert "abc123" in calls[3][0][0]
+        # push
+        assert "push" in calls[4][0][0]
+        assert "f44-pkg-1.0-2" in calls[4][0][0]
+
+    @mock.patch("rpmautospec_koji.rpmautospec_git_tag_task.subprocess.run")
+    def test_handler_no_scheme_prefix(self, mock_run):
+        mock_run.return_value = mock.MagicMock(returncode=0)
+        task = self._make_task()
+        task.handler("https://src.example.com/rpms/pkg#abc123", "f44-pkg-1.0-2")
+
+        calls = mock_run.call_args_list
+        assert "https://src.example.com/rpms/pkg" in calls[1][0][0]
+
+    @mock.patch("rpmautospec_koji.rpmautospec_git_tag_task.subprocess.run")
+    def test_handler_custom_scheme_prefix(self, mock_run):
+        mock_run.return_value = mock.MagicMock(returncode=0)
+        task = self._make_task()
+        task.handler(
+            "custom+https://git.example.com/v1/repos/pkg#abc123",
+            "f44-pkg-1.0-2",
+        )
+
+        calls = mock_run.call_args_list
+        assert "https://git.example.com/v1/repos/pkg" in calls[1][0][0]
+
+    @mock.patch("rpmautospec_koji.rpmautospec_git_tag_task.subprocess.run")
+    def test_handler_git_failure(self, mock_run):
+        mock_run.return_value = mock.MagicMock(
+            returncode=128, stderr=b"fatal: repository not found"
+        )
+        task = self._make_task()
+        with pytest.raises(koji.GenericError, match="repository not found"):
+            task.handler("git+https://src.example.com/rpms/pkg#abc123", "f44-pkg-1.0-2")
+
+    def test_handler_missing_hash(self):
+        task = self._make_task()
+        with pytest.raises(koji.GenericError, match="missing commit hash"):
+            task.handler("git+https://src.example.com/rpms/pkg", "f44-pkg-1.0-2")
+
+    @mock.patch("rpmautospec_koji.rpmautospec_git_tag_task.subprocess.run")
+    def test_handler_timeout(self, mock_run):
+        """TimeoutExpired from subprocess propagates as an error."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=60)
+        task = self._make_task()
+        with pytest.raises(subprocess.TimeoutExpired):
+            task.handler("git+https://src.example.com/rpms/pkg#abc123", "fedora/f44/pkg-1.0-2")
+
+
+class TestTaggerReaderRoundTrip:
+    """Verify tagger output is parseable by the reader (nvr_util)."""
+
+    def test_format_then_parse(self):
+        """format_namespaced_nvr → parse_namespaced_nvr round-trip."""
+        from rpmautospec_core.nvr_util import format_namespaced_nvr, parse_namespaced_nvr
+
+        # Simple case
+        tag = format_namespaced_nvr("fedora/f44", "mesa", "26.0.7", "2")
+        parsed = parse_namespaced_nvr(tag, "fedora/f44")
+        assert parsed["name"] == "mesa"
+        assert parsed["version"] == "26.0.7"
+        assert parsed["release"] == "2"
+        assert parsed["epoch"] == ""
+
+    def test_format_then_parse_with_epoch(self):
+        from rpmautospec_core.nvr_util import format_namespaced_nvr, parse_namespaced_nvr
+
+        tag = format_namespaced_nvr("fedora/f44", "httpd", "2.4.57", "1", epoch="2")
+        parsed = parse_namespaced_nvr(tag, "fedora/f44")
+        assert parsed["name"] == "httpd"
+        assert parsed["version"] == "2.4.57"
+        assert parsed["release"] == "1"
+        assert parsed["epoch"] == "2"
+
+    def test_dist_suffix_stripping_compat(self):
+        """Tagger strips dist suffix before formatting; reader parses the result."""
+        from rpmautospec_core.nvr_util import format_namespaced_nvr, parse_namespaced_nvr
+
+        # Tagger does: release = "93.fc44".split(".")[0] = "93"
+        release_from_koji = "93.fc44"
+        stripped = release_from_koji.split(".")[0]
+        tag = format_namespaced_nvr("fedora/f44", "pkg", "1.0", stripped)
+        parsed = parse_namespaced_nvr(tag, "fedora/f44")
+        assert parsed["release"] == "93"
+
+    def test_epoch_zero_omitted(self):
+        """Epoch 0 is the RPM default and is not included in the tag."""
+        from rpmautospec_core.nvr_util import format_namespaced_nvr, parse_namespaced_nvr
+
+        tag = format_namespaced_nvr("fedora/f44", "pkg", "1.0", "1", epoch="0")
+        # epoch 0 is implicit, not encoded in the tag
+        assert tag == "fedora/f44/pkg-1.0-1"
+        parsed = parse_namespaced_nvr(tag, "fedora/f44")
+        assert parsed["epoch"] == ""
+        assert parsed["name"] == "pkg"

--- a/tests/test_rpmautospec_tagger.py
+++ b/tests/test_rpmautospec_tagger.py
@@ -1,0 +1,241 @@
+import logging
+import sys
+from unittest import mock
+
+import pytest
+
+sys.modules["kojihub"] = mock.MagicMock()
+
+from pathlib import Path
+
+from rpmautospec_koji import rpmautospec_tagger
+from rpmautospec_koji.rpmautospec_tagger import _get_config, create_git_tag_on_tag
+
+
+class TestGetConfig:
+    """Test _get_config reads real config files."""
+
+    def setup_method(self):
+        rpmautospec_tagger._config = None
+
+    def test_no_config_file(self, tmp_path):
+        rpmautospec_tagger._config = None
+        with mock.patch.object(rpmautospec_tagger, "CONFIG_FILE", str(tmp_path / "missing.conf")):
+            assert _get_config() == {"git_tag_rules": []}
+
+    def test_full_config(self):
+        rpmautospec_tagger._config = None
+        conf = str(Path(__file__).parent / "fixtures" / "tagger_full.conf")
+        with mock.patch.object(rpmautospec_tagger, "CONFIG_FILE", conf):
+            result = _get_config()
+        assert result["git_tag_rules"] == [
+            (r"(f\d+)-updates", r"fedora/\1"),
+        ]
+
+
+    def test_malformed_entry_skipped(self):
+        rpmautospec_tagger._config = None
+        conf = str(Path(__file__).parent / "fixtures" / "tagger_malformed.conf")
+        with mock.patch.object(rpmautospec_tagger, "CONFIG_FILE", conf):
+            result = _get_config()
+        assert result["git_tag_rules"] == [(r"(f\d+)-updates", r"fedora/\1")]
+
+
+    def test_section_without_rules(self, tmp_path):
+        conf = tmp_path / "rpmautospec.conf"
+        conf.write_text("[rpmautospec]\n")
+        rpmautospec_tagger._config = None
+        with mock.patch.object(rpmautospec_tagger, "CONFIG_FILE", str(conf)):
+            assert _get_config() == {"git_tag_rules": []}
+
+    def test_caches_result(self, tmp_path):
+        conf = tmp_path / "rpmautospec.conf"
+        conf.write_text("[rpmautospec]\ngit_tag_rules =\n    (f\\d+)-updates = fedora/\\1\n")
+        rpmautospec_tagger._config = None
+        with mock.patch.object(rpmautospec_tagger, "CONFIG_FILE", str(conf)):
+            first = _get_config()
+            second = _get_config()
+        assert first is second
+        assert first["git_tag_rules"] == [(r"(f\d+)-updates", r"fedora/\1")]
+
+
+class TestTaggerPlugin:
+    """Test the rpmautospec tagger hub plugin."""
+
+    sample_build = {
+        "name": "pkg",
+        "version": "1.0",
+        "release": "2.fc44",
+        "epoch": None,
+        "nvr": "pkg-1.0-2.fc44",
+        "source": "git+https://src.example.com/rpms/pkg#abc123",
+        "task_id": 12345,
+    }
+
+    def _patch_config(self, config):
+        rpmautospec_tagger._config = None
+        return mock.patch.object(rpmautospec_tagger, "_get_config", return_value=config)
+
+    @pytest.mark.parametrize(
+        "testcase",
+        (
+            "matching tag",
+            "non-matching tag",
+            "no rules configured",
+            "no source in build",
+            "non-numeric release",
+            "epoch zero",
+            "make_task exception",
+        ),
+    )
+    @mock.patch("rpmautospec_koji.rpmautospec_tagger.make_task")
+    def test_git_tag_on_koji_tag(self, make_task_fn, testcase, caplog):
+        # Strict write rule: only f44-updates triggers
+        config = {"git_tag_rules": [(r"(f\d+)-updates", r"fedora/\1")]}
+
+        tag = {"name": "f44-updates"}
+        build = dict(self.sample_build)
+
+        if testcase == "non-matching tag":
+            tag = {"name": "f44-updates-candidate"}
+        elif testcase == "no rules configured":
+            config["git_tag_rules"] = []
+        elif testcase == "no source in build":
+            build["source"] = None
+        elif testcase == "non-numeric release":
+            build["release"] = "rc1.fc44"
+        elif testcase == "epoch zero":
+            build["epoch"] = 0
+        elif testcase == "make_task exception":
+            make_task_fn.side_effect = Exception("connection failed")
+
+        with self._patch_config(config), caplog.at_level(logging.DEBUG):
+            create_git_tag_on_tag("postTag", tag=tag, build=build, user={"name": "releng"})
+
+        if testcase == "matching tag":
+            make_task_fn.assert_called_once_with(
+                "createGitTag",
+                [build["source"], "fedora/f44/pkg-1.0-2"],
+                priority=mock.ANY,
+                channel="default",
+            )
+        elif testcase == "epoch zero":
+            make_task_fn.assert_called_once_with(
+                "createGitTag",
+                [build["source"], "fedora/f44/pkg-1.0-2"],
+                priority=mock.ANY,
+                channel="default",
+            )
+        elif testcase == "make_task exception":
+            make_task_fn.assert_called_once()
+            assert "Failed to spawn" in caplog.text
+        else:
+            make_task_fn.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "koji_tag, expected_namespace",
+        [
+            ("f44-updates", "fedora/f44"),
+            ("f43-updates", "fedora/f43"),
+            ("f44-updates-candidate", None),
+
+        ],
+        ids=["fedora-f44", "fedora-f43", "candidate-no-match"],
+    )
+    @mock.patch("rpmautospec_koji.rpmautospec_tagger.make_task")
+    def test_multi_rule_resolution(self, make_task_fn, koji_tag, expected_namespace):
+        """Multiple rules: multiple Fedora releases on same Koji."""
+        config = {"git_tag_rules": [
+            (r"(f\d+)-updates", r"fedora/\1"),
+        ]}
+        build = dict(self.sample_build)
+
+        with self._patch_config(config):
+            create_git_tag_on_tag("postTag", tag={"name": koji_tag}, build=build, user={"name": "releng"})
+
+        if expected_namespace:
+            expected_tag = f"{expected_namespace}/pkg-1.0-2"
+            make_task_fn.assert_called_once_with(
+                "createGitTag",
+                [build["source"], expected_tag],
+                priority=mock.ANY,
+                channel="default",
+            )
+        else:
+            make_task_fn.assert_not_called()
+
+    @mock.patch("rpmautospec_koji.rpmautospec_tagger.make_task")
+    def test_tag_skips_draft_build(self, make_task_fn):
+        config = {"git_tag_rules": [(r"(f\d+)-updates", r"fedora/\1")]}
+        build = dict(self.sample_build, draft=True)
+
+        with self._patch_config(config):
+            create_git_tag_on_tag("postTag", tag={"name": "f44-updates"}, build=build, user={"name": "releng"})
+
+        make_task_fn.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "testcase",
+        ("matching tag", "non-matching tag", "no rules", "no source", "exception"),
+    )
+    @mock.patch("rpmautospec_koji.rpmautospec_tagger.make_task")
+    def test_promote(self, make_task_fn, testcase, caplog):
+        config = {"git_tag_rules": [(r"(f\d+)-updates", r"fedora/\1")]}
+        build = dict(self.sample_build, build_id=99)
+        kojihub_mock = sys.modules["kojihub"]
+
+        if testcase == "matching tag":
+            kojihub_mock.context.handlers.call.return_value = [{"name": "f44-updates"}]
+        elif testcase == "non-matching tag":
+            kojihub_mock.context.handlers.call.return_value = [{"name": "f44-updates-candidate"}]
+        elif testcase == "no rules":
+            config = {"git_tag_rules": []}
+        elif testcase == "no source":
+            build["source"] = None
+            kojihub_mock.context.handlers.call.return_value = [{"name": "f44-updates"}]
+        elif testcase == "exception":
+            kojihub_mock.context.handlers.call.side_effect = Exception("connection lost")
+
+        with self._patch_config(config), caplog.at_level(logging.DEBUG):
+            from rpmautospec_koji.rpmautospec_tagger import create_git_tag_on_promote
+            create_git_tag_on_promote("postBuildPromote", build=build, user={"name": "releng"})
+
+        kojihub_mock.context.handlers.call.side_effect = None
+
+        if testcase == "matching tag":
+            make_task_fn.assert_called_once_with(
+                "createGitTag",
+                [build["source"], "fedora/f44/pkg-1.0-2"],
+                priority=mock.ANY,
+                channel="default",
+            )
+        elif testcase == "exception":
+            make_task_fn.assert_not_called()
+            assert "Failed to look up tags" in caplog.text
+        else:
+            make_task_fn.assert_not_called()
+
+    @mock.patch("rpmautospec_koji.rpmautospec_tagger.make_task")
+    def test_promote_multiple_matching_tags_uses_first(self, make_task_fn):
+        """When multiple tags match, only the first triggers a createGitTag task."""
+        config = {"git_tag_rules": [(r"(f\d+)-updates", r"fedora/\1")]}
+        build = dict(self.sample_build, build_id=99)
+        kojihub_mock = sys.modules["kojihub"]
+        kojihub_mock.context.handlers.call.return_value = [
+            {"name": "f44-updates"},
+            {"name": "f43-updates"},
+        ]
+
+        with self._patch_config(config):
+            from rpmautospec_koji.rpmautospec_tagger import create_git_tag_on_promote
+            create_git_tag_on_promote("postBuildPromote", build=build, user={"name": "releng"})
+
+        kojihub_mock.context.handlers.call.side_effect = None
+
+        # Only one task spawned (first match wins)
+        make_task_fn.assert_called_once_with(
+            "createGitTag",
+            [build["source"], "fedora/f44/pkg-1.0-2"],
+            priority=mock.ANY,
+            channel="default",
+        )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+
+import pytest
+from rpmautospec_koji.util import match_tag_rules, parse_config, parse_tag_rules
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class TestMatchTagRules:
+    """Tests for match_tag_rules with regex capture groups."""
+
+    @pytest.mark.parametrize(
+        "tag_name, expected",
+        [
+            ("f44-updates", "fedora/f44"),
+            ("f43-updates", "fedora/f43"),
+            ("f44-updates-candidate", None),
+
+            ("random-tag", None),
+        ],
+        ids=["fedora-f44", "fedora-f43", "candidate-no-match", "random-no-match"],
+    )
+    def test_multi_rule(self, tag_name, expected):
+        rules = [
+            (r"(f\d+)-updates", r"fedora/\1"),
+        ]
+        assert match_tag_rules(tag_name, rules) == expected
+
+    def test_static_template(self):
+        rules = [(r"f\d+-updates", "distro/release")]
+        assert match_tag_rules("f44-updates", rules) == "distro/release"
+
+    def test_multiple_capture_groups(self):
+        rules = [(r"(\w+)-(\d+)-updates", r"fedora/\1\2")]
+        assert match_tag_rules("fedora-44-updates", rules) == "fedora/fedora44"
+
+    def test_empty_rules(self):
+        assert match_tag_rules("f44-updates", []) is None
+
+    def test_first_match_wins(self):
+        rules = [
+            (r"f44-updates", "specific/f44"),
+            (r"f\d+-updates", r"generic/\1"),
+        ]
+        assert match_tag_rules("f44-updates", rules) == "specific/f44"
+
+    def test_builder_pattern(self):
+        """Builder uses build tag (e.g. f44-build) to derive read namespace."""
+        rules = [(r"(f\d+)-build", r"fedora/\1")]
+        assert match_tag_rules("f44-build", rules) == "fedora/f44"
+        assert match_tag_rules("f43-build", rules) == "fedora/f43"
+        assert match_tag_rules("random-tag", rules) is None
+
+
+class TestParseTagRules:
+    """Tests for parse_tag_rules config file parsing."""
+
+    def test_reads_newline_separated_rules(self):
+        rules = parse_tag_rules(str(FIXTURES_DIR / "tagger_full.conf"))
+        assert rules == [(r"(f\d+)-updates", r"fedora/\1")]
+
+    def test_skips_malformed_entries(self):
+        rules = parse_tag_rules(str(FIXTURES_DIR / "tagger_malformed.conf"))
+        assert rules == [(r"(f\d+)-updates", r"fedora/\1")]
+
+    def test_builder_config(self):
+        rules = parse_tag_rules(str(FIXTURES_DIR / "builder_full.conf"))
+        assert rules == [(r"(f\d+)(-.*)?", r"fedora/\1")]
+
+    def test_missing_file(self, tmp_path):
+        rules = parse_tag_rules(str(tmp_path / "nonexistent.conf"))
+        assert rules == []
+
+    def test_no_section(self, tmp_path):
+        conf = tmp_path / "empty.conf"
+        conf.write_text("")
+        assert parse_tag_rules(str(conf)) == []
+
+    def test_regex_with_quantifier(self, tmp_path):
+        """Comma in {2,3} doesn't break parsing (newline-separated)."""
+        conf = tmp_path / "quantifier.conf"
+        conf.write_text("[rpmautospec]\ngit_tag_rules =\n    (f\\d{2,3})-build = fedora/\\1\n")
+        rules = parse_tag_rules(str(conf))
+        assert rules == [(r"(f\d{2,3})-build", r"fedora/\1")]
+
+    def test_regex_with_colon(self, tmp_path):
+        """Colon in regex (e.g. non-capturing group) doesn't break parsing."""
+        conf = tmp_path / "colon.conf"
+        conf.write_text("[rpmautospec]\ngit_tag_rules =\n    (?:f|el)(\\d+)-updates = distro/\\1\n")
+        rules = parse_tag_rules(str(conf))
+        assert rules == [(r"(?:f|el)(\d+)-updates", r"distro/\1")]
+
+
+class TestParseConfig:
+    """Tests for parse_config with changelog options."""
+
+    def test_defaults(self, tmp_path):
+        conf = tmp_path / "empty.conf"
+        conf.write_text("[rpmautospec]\n")
+        result = parse_config(str(conf))
+        assert result["git_tag_rules"] == []
+        assert result["changelog_mode"] == "accumulated"
+        assert result["changelog_use_highest_release_tag"] is False
+
+    def test_all_options(self, tmp_path):
+        conf = tmp_path / "full.conf"
+        conf.write_text(
+            "[rpmautospec]\n"
+            "git_tag_rules =\n"
+            "    (f\\d+)-updates = fedora/\\1\n"
+            "changelog_mode = tagged-only\n"
+            "changelog_use_highest_release_tag = true\n"
+        )
+        result = parse_config(str(conf))
+        assert result["git_tag_rules"] == [(r"(f\d+)-updates", r"fedora/\1")]
+        assert result["changelog_mode"] == "tagged-only"
+        assert result["changelog_use_highest_release_tag"] is True
+
+    def test_highest_release_various_truthy(self, tmp_path):
+        for val in ("yes", "1", "True", "TRUE"):
+            conf = tmp_path / "t.conf"
+            conf.write_text(f"[rpmautospec]\nchangelog_use_highest_release_tag = {val}\n")
+            assert parse_config(str(conf))["changelog_use_highest_release_tag"] is True
+
+    def test_highest_release_falsy(self, tmp_path):
+        conf = tmp_path / "f.conf"
+        conf.write_text("[rpmautospec]\nchangelog_use_highest_release_tag = false\n")
+        assert parse_config(str(conf))["changelog_use_highest_release_tag"] is False


### PR DESCRIPTION
[I have added mechanics to Rpmautospec to use namespaced tags of N-V-Rs to codify release history & enhance autorelease/autochangelog to better reflect reality.](https://github.com/fedora-infra/rpmautospec/pull/397)

To enable usage in Koji, I have made a few enhancements:

1. I have added the ability to use git tags based on matching Koji tag rules (more below).
2. I have added added a new Koji post-task trigger (Hub plugin) and subtask (Builder plugin) to create git tags based on rules.

By default, Koji will still use the current behavior. The new git tag behavior will only be enabled if relevant config is added.

Git tag rules are a regex tested against Koji operation tags to translate to git tags. These are defined independently for the builder and hub.
* Builder tag rules are for "read" tags used to pass namespaces to Rpmautospec. For example, the rule "(f\d+)-.+":"fedora/\1" would match all "f44-*" tags (like f44-updates, etc) and translate to "fedora/f44". These are expected to be somewhat loose so side tags, derivative targets, etc can still match rules from the main OS tags.
* Hub tag rules are "write" tags used for Git writeback. For example, defining the rule "(f\d+)-updates":"fedora/\1" would cause only "f44-updates" to write to the fedora/f44 namespace. This are intended to be strictly scoped only to critical-path tags for actual releases.

The hub post-task plugin will trigger git writeback on the following conditions:
* The task was either TagBuild or Promote (draft)
* The build, as a result, is a non-scratch non-draft build in a matching Koji tag

I have bumped minor version given this is new functionality/enhancement and to better delineate dependency versions across all Rpmautospec component packages.

_Note: While this was drafted by Amazon Linux, we are not using the hub-side plugin to trigger Git writeback. Due to how we model source control & build system permissions, we instead have a separate AWS Lambda system triggered by a separate post-task SNS plugin we use internally._